### PR TITLE
Update nginx.conf 

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -17,7 +17,8 @@ http {
     access_log /dev/stdout access;
     include manager_server.conf;
     underscores_in_headers on; 
-
+    server_names_hash_bucket_size 64;
+    
     server {
         listen   80;
 


### PR DESCRIPTION
[UPDATE] increase  the server_names_hash_bucket_size to 64. fix the wrong info "could not build server_names_hash, you should increase server_names_hash_bucket_size: 32"